### PR TITLE
Added innodb_use_native_aio=0 in my.cnf in 5.6

### DIFF
--- a/5.6/my.cnf
+++ b/5.6/my.cnf
@@ -5,6 +5,8 @@ skip_name_resolve
 #server-id
 #log-bin
 
+innodb_use_native_aio=0 
+
 innodb_buffer_pool_size=5M
 innodb_log_buffer_size=256K
 query_cache_size=0


### PR DESCRIPTION
This should resolve

```
2016-07-15 10:05:36 7f04fa22a780 InnoDB: Warning: io_setup() failed with EAGAIN. Will make 5 attempts before giving up.
InnoDB: Warning: io_setup() attempt 1 failed.
InnoDB: Warning: io_setup() attempt 2 failed.
InnoDB: Warning: io_setup() attempt 3 failed.
InnoDB: Warning: io_setup() attempt 4 failed.
InnoDB: Warning: io_setup() attempt 5 failed.
2016-07-15 10:05:38 7f04fa22a780 InnoDB: Error: io_setup() failed with EAGAIN after 5 attempts.
InnoDB: You can disable Linux Native AIO by setting innodb_use_native_aio = 0 in my.cnf
2016-07-15 10:05:38 924 [ERROR] InnoDB: Fatal : Cannot initialize AIO sub-system
2016-07-15 10:05:38 924 [ERROR] Plugin 'InnoDB' init function returned error.
2016-07-15 10:05:38 924 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed.
2016-07-15 10:05:38 924 [ERROR] Unknown/unsupported storage engine: InnoDB
2016-07-15 10:05:38 924 [ERROR] Aborting
```
